### PR TITLE
Bump Version specifier to allow newer Click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.6"
-click = "^7.1.2"
+click = ">=7.1.2,<9"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.2"


### PR DESCRIPTION
In order to support installing human_id alongside packages which require click>=8, such as the latest versions of celery, bump to allow up to click 9.

Closes #1 