### PR TITLE
Update for new seeding behavior in py3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ generate_id(word_count=10)
 
 # Custom seed - the same UUID will produce the same ID.
 import uuid
-generate_id(seed=uuid.uuid4())
+generate_id(seed=uuid.uuid4().int)
 ```
 
 ## CLI

--- a/human_id/__init__.py
+++ b/human_id/__init__.py
@@ -1,14 +1,14 @@
 import random
 import itertools
-from typing import Hashable
+from typing import Union
 from . import dictionary
 
 __all__ = ["generate_id"]
 
 system_random = random.SystemRandom()
+SeedableType = Union[type(None), int, float, str, bytes, bytearray]
 
-
-def generate_id(separator="-", seed: Hashable = None, word_count=4) -> str:
+def generate_id(separator="-", seed: SeedableType = None, word_count=4) -> str:
     """
     Generate a human readable ID
 


### PR DESCRIPTION
Dear Maintainer

In latest Python versions, the behavior of seeding has changed. Instead of accepting any hashable type, the seed must now be
Nonetype, int, float, str, bytes, or bytearray. The old behavior is deprecated in python3.10 and raises an error in python3.11.

For example, the output of uuid.uuid4() can no longer be (directly) used as a seed for random.SystemRandom and thus cannot be used as a seed for human_id.generate_id()

This pull request changes the sample code to be compatible with py3.11, and also updates the type annotation of generate_id to reflect the new behavior of the random module.

Regards, Nikita.